### PR TITLE
Feature/nice tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.au/datavizkit",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A fully featured data visualisation toolset built on top of Highcharts and React.",
   "keywords": [
     "highcharts",

--- a/src/components/withHeroChart.js
+++ b/src/components/withHeroChart.js
@@ -56,6 +56,7 @@ const withHeroChart = (ComposedComponent) => {
           height: 360,
           events: {
             click: function(e) { 
+              console.log("Hello");
               if (this.tooltip && this.tooltip.label) {
                 switch(this.tooltip.label.attr('visibility')) {
                 case 'hidden':
@@ -117,7 +118,23 @@ const withHeroChart = (ComposedComponent) => {
             const value = `${units === '$' ? '$' : ''}${this.y}${units === '%' ? '%' : ''}`;
 
             return `<tr>
-                      <td><span style="font-size:20px; color: ${this.series.color}">${symbol}</span></td>
+                      <td>
+                        <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                              <g id="WOG-2015-?4" transform="translate(-596.000000, -1032.000000)" fill="#CF7E33">
+                                  <g id="Group-44" transform="translate(590.000000, 946.000000)">
+                                      <g id="TT_UserSatisfaction" transform="translate(6.000000, 87.000000)">
+                                          <g id="Group-22" transform="translate(0.000000, 4.000000)">
+                                              <rect id="Rectangle-15" x="0" y="0" width="25" height="3" rx="1.5"></rect>
+                                          </g>
+                                          <circle id="Oval-5" stroke="#FFFFFF" cx="12.5" cy="5.5" r="5.5"></circle>
+                                      </g>
+                                  </g>
+                              </g>
+                          </g>
+                      </svg>
+                      <!--<span style="font-size:20px; color: ${this.series.color}">${symbol}</span>-->
+                      </td>
                       <td style="text-align: right;"><strong>${value}</strong></td>
                     </tr>`;
           },

--- a/src/components/withHeroChart.js
+++ b/src/components/withHeroChart.js
@@ -4,7 +4,7 @@ import merge from 'lodash/merge';
 import isObject from 'lodash/isObject';
 
 import {createHighcontrastDashSeriesIteratee} from './../utils/highcontrastPatterns';
-import {symbolChars} from './../utils/displayFormats';
+import {tooltipMarker} from './../utils/displayFormats';
 
 
 const withHeroChart = (ComposedComponent) => {
@@ -56,7 +56,6 @@ const withHeroChart = (ComposedComponent) => {
           height: 360,
           events: {
             click: function(e) { 
-              console.log("Hello");
               if (this.tooltip && this.tooltip.label) {
                 switch(this.tooltip.label.attr('visibility')) {
                 case 'hidden':
@@ -110,35 +109,27 @@ const withHeroChart = (ComposedComponent) => {
           shared: true,
           crosshairs: true,
           borderRadius: 8,
-          headerFormat: '<small>{point.key}</small><table>',
-          pointFormatter: function() {
-            // this refers tp "Point"
-            const {units} = this.series.options;
-            const symbol = symbolChars[this.series.symbol];
-            const value = `${units === '$' ? '$' : ''}${this.y}${units === '%' ? '%' : ''}`;
+          formatter: function() {
+            const label = this.points[0].series.chart.options.xCategories[this.points[0].x]
 
-            return `<tr>
-                      <td>
-                        <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                              <g id="WOG-2015-?4" transform="translate(-596.000000, -1032.000000)" fill="#CF7E33">
-                                  <g id="Group-44" transform="translate(590.000000, 946.000000)">
-                                      <g id="TT_UserSatisfaction" transform="translate(6.000000, 87.000000)">
-                                          <g id="Group-22" transform="translate(0.000000, 4.000000)">
-                                              <rect id="Rectangle-15" x="0" y="0" width="25" height="3" rx="1.5"></rect>
-                                          </g>
-                                          <circle id="Oval-5" stroke="#FFFFFF" cx="12.5" cy="5.5" r="5.5"></circle>
-                                      </g>
-                                  </g>
-                              </g>
-                          </g>
-                      </svg>
-                      <!--<span style="font-size:20px; color: ${this.series.color}">${symbol}</span>-->
-                      </td>
-                      <td style="text-align: right;"><strong>${value}</strong></td>
-                    </tr>`;
+            const rows = this.points.map(function(point) {
+              const {units} = point.series.options;
+              const value = `${units === '$' ? '$' : ''}${point.y}${units === '%' ? '%' : ''}`;
+              const marker = tooltipMarker(point.series.symbol, point.series.color);
+              
+              return `<tr>
+                        <td>
+                          ${marker}
+                        </td>
+                        <td style="text-align: right;"><strong>${value}</strong></td>
+                      </tr>`;
+            });
+
+            return `<small>${label}</small>
+              <table style="width:100%">
+                ${rows.join('')}
+              </table>`;
           },
-          footerFormat: '</table>',
           useHTML: true
         },
         xAxis: {
@@ -169,8 +160,9 @@ const withHeroChart = (ComposedComponent) => {
             formatter: function () {
               return chartConfig.xAxis.categories[this.value];
             }
-          }
+          }          
         },
+        xCategories: chartConfig.xAxis.categories,
         yAxis: chartConfig.yAxis,
         series: chartConfig.series.map(s => {
           if (isObject(s.data[0])) {

--- a/src/utils/displayFormats.js
+++ b/src/utils/displayFormats.js
@@ -9,6 +9,10 @@ export const symbolChars = {
   'square': '■',
   'triangle-down': '▾' };
 
+export const symbolSvg = function(symbol) { 
+
+};
+
 export const valueFormats = {
   'percentage': val => `${Highcharts.numberFormat(val, 2)}%`,
   'money': function(val) { return `$${val}`; }

--- a/src/utils/displayFormats.js
+++ b/src/utils/displayFormats.js
@@ -1,17 +1,12 @@
 
 import Highcharts from 'highcharts';
 
-
 export const symbolChars = {
   'circle': '●',
   'diamond': '◆',
   'triangle': '▴',
   'square': '■',
   'triangle-down': '▾' };
-
-export const symbolSvg = function(symbol) { 
-
-};
 
 export const valueFormats = {
   'percentage': val => `${Highcharts.numberFormat(val, 2)}%`,
@@ -41,4 +36,97 @@ export const valueWithUnits = (value, units) => {
   default:
     return `${op} ${val}`;
   }
+};
+
+export const tooltipMarker = function(symbolName, color) { 
+  let markerFuncs = {
+    'circle': function(color) {
+      return `<svg width="25px" height="13px" viewBox="0 0 25 13" version="1.1"
+            xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <title>TT_UserSatisfaction</title>
+          <desc>Created with Sketch.</desc>
+          <defs></defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g id="WOG-2015-?4" transform="translate(-596.000000, -1032.000000)" fill="${color}">
+                  <g id="Group-44" transform="translate(590.000000, 946.000000)">
+                      <g id="TT_UserSatisfaction" transform="translate(6.000000, 87.000000)">
+                          <g id="Group-22" transform="translate(0.000000, 4.000000)">
+                              <rect id="Rectangle-15" x="0" y="0" width="25" height="3" rx="1.5"></rect>
+                          </g>
+                          <circle id="Oval-5" stroke="#FFFFFF" cx="12.5" cy="5.5" r="5.5"></circle>
+                      </g>
+                  </g>
+              </g>
+          </g>
+      </svg>`;
+    },
+    'diamond': function(color) {
+      return `<svg width="25px" height="17px" viewBox="0 0 25 17" version="1.1" 
+            xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <title>TT_CostPerTransaction</title>
+          <desc>Created with Sketch.</desc>
+          <defs>
+              <rect id="path-1" x="7.86396103" y="1.86396103" width="9" height="9"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g id="WOG-2015-?4" transform="translate(-596.000000, -959.000000)">
+                  <g id="Group-44" transform="translate(590.000000, 946.000000)">
+                      <g id="TT_CostPerTransaction" transform="translate(6.000000, 15.000000)">
+                          <rect id="Rectangle-15" fill="${color}" x="0" y="5" width="25" height="3" rx="1.5"></rect>
+                          <g id="Rectangle-16" transform="translate(12.363961, 6.363961) rotate(45.000000) translate(-12.363961, -6.363961) ">
+                              <use fill="${color}" fill-rule="evenodd" xlink:href="#path-1"></use>
+                              <rect stroke="#FFFFFF" stroke-width="1" x="7.36396103" y="1.36396103" width="10" height="10"></rect>
+                          </g>
+                      </g>
+                  </g>
+              </g>
+          </g>
+      </svg>`;
+    },
+    'triangle': function(color) { 
+      return `<svg width="25px" height="14px" viewBox="0 0 25 14" version="1.1" 
+            xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <title>Rectangle-15</title>
+          <desc>Created with Sketch.</desc>
+          <defs></defs>
+          <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g id="Rectangle-15">
+                  <g id="Group-3">
+                      <rect id="Rectangle-15" fill="#6E63A7" fill-rule="nonzero" x="0" y="6" width="25" height="3" rx="1.5"></rect>
+                      <g id="Group-2" transform="translate(2.000000, 0.000000)">
+                          <g id="Rectangle-16" transform="translate(10.560000, 10.182254) rotate(45.000000) translate(-10.560000, -10.182254) translate(3.560000, 3.182254)">
+                              <g id="path-1-link" transform="translate(1.000000, 1.000000)" fill="#6E63A7">
+                                  <polygon id="path-1" points="0 0 11.1199999 2.99452777 2.99452777 11.1199999"></polygon>
+                              </g>
+                              <polygon id="Shape" stroke="#FFFFFF" points="0.29135534 0.29135534 13.085041 3.73659341 3.73659341 13.085041"></polygon>
+                          </g>
+                      </g>
+                  </g>
+              </g>
+          </g>
+      </svg>`;
+    },
+    'square': function(color) { 
+      return `<svg width="25px" height="13px" viewBox="0 0 25 13" version="1.1" 
+            xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <title>TT_DigitalTakeUp</title>
+          <desc>Created with Sketch.</desc>
+          <defs></defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g id="WOG-2015-?4" transform="translate(-596.000000, -985.000000)" fill="${color}">
+                  <g id="Group-44" transform="translate(590.000000, 946.000000)">
+                      <g id="TT_DigitalTakeUp" transform="translate(6.000000, 40.000000)">
+                          <rect id="Rectangle-15" x="0" y="4" width="25" height="3" rx="1.5"></rect>
+                          <rect id="Rectangle-16" stroke="#FFFFFF" x="7" y="0" width="11" height="11"></rect>
+                      </g>
+                  </g>
+              </g>
+          </g>
+      </svg>`;
+    }
+    //TODO: triangle-down
+  };
+
+  let func = markerFuncs[symbolName] || markerFuncs['circle'];
+  return func(color);
 };


### PR DESCRIPTION
Use Nick's SVGs for the tooltips rather than text symbols. Result is better, I feel like the code could be DRY'd up but not quite sure how at this point...

n.b. I had to change from separate point/header/footer formats to the all-in-one `formatter` function because since I'd changed the X Axis categories there was bug in the header of the tooltip, and fixing it wasn't possible because `headerFormat` string only takes very basic substitutions and it is now (necessarily) a bit complex to pull out the name of the x-axis category. 